### PR TITLE
Fix error in migration

### DIFF
--- a/db/migrate/20150522214144_create_baseline.shipit_engine.rb
+++ b/db/migrate/20150522214144_create_baseline.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20140226233935)
-class CreateBaseline < ActiveRecord::Migration
+class CreateBaseline < ActiveRecord::Migration[4.2]
   def change
     create_table "api_clients", force: :cascade do |t|
       t.text     "permissions", limit: 65535

--- a/db/migrate/20150522214145_add_output_column_to_tasks.shipit_engine.rb
+++ b/db/migrate/20150522214145_add_output_column_to_tasks.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20150515190352)
-class AddOutputColumnToTasks < ActiveRecord::Migration
+class AddOutputColumnToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :gzip_output, :binary, limit: 16777215
   end

--- a/db/migrate/20150522214146_add_ignore_ci_to_stack.shipit_engine.rb
+++ b/db/migrate/20150522214146_add_ignore_ci_to_stack.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20150518214944)
-class AddIgnoreCiToStack < ActiveRecord::Migration
+class AddIgnoreCiToStack < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :ignore_ci, :boolean
   end

--- a/db/migrate/20150705181616_add_inaccessible_since_to_stacks.shipit_engine.rb
+++ b/db/migrate/20150705181616_add_inaccessible_since_to_stacks.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20150630154640)
-class AddInaccessibleSinceToStacks < ActiveRecord::Migration
+class AddInaccessibleSinceToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :inaccessible_since, :datetime, default: nil
   end

--- a/db/migrate/20151208214750_add_rollback_when_complete_on_task.shipit_engine.rb
+++ b/db/migrate/20151208214750_add_rollback_when_complete_on_task.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20150708143032)
-class AddRollbackWhenCompleteOnTask < ActiveRecord::Migration
+class AddRollbackWhenCompleteOnTask < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :rollback_once_aborted, :boolean, default: false, null: false
   end

--- a/db/migrate/20151208214751_add_env_to_tasks.shipit_engine.rb
+++ b/db/migrate/20151208214751_add_env_to_tasks.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20150814182557)
-class AddEnvToTasks < ActiveRecord::Migration
+class AddEnvToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :env, :text
   end

--- a/db/migrate/20151208214752_add_confirmations_to_tasks.shipit_engine.rb
+++ b/db/migrate/20151208214752_add_confirmations_to_tasks.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20150918190012)
-class AddConfirmationsToTasks < ActiveRecord::Migration
+class AddConfirmationsToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :confirmations, :integer, default: 0, null: false
   end

--- a/db/migrate/20151208214753_schema_constraints_cleanup.shipit_engine.rb
+++ b/db/migrate/20151208214753_schema_constraints_cleanup.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20151102201634)
-class SchemaConstraintsCleanup < ActiveRecord::Migration
+class SchemaConstraintsCleanup < ActiveRecord::Migration[4.2]
   # Set reasonable size limit to a bunch of indexed string columns. They were defaulted to 255
   def change
     change_column :github_hooks, :event, :string, limit: 50, null: false # The biggest existing event is 27

--- a/db/migrate/20151208214754_convert_stacks_lock_reason_to_text.shipit_engine.rb
+++ b/db/migrate/20151208214754_convert_stacks_lock_reason_to_text.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20151103144716)
-class ConvertStacksLockReasonToText < ActiveRecord::Migration
+class ConvertStacksLockReasonToText < ActiveRecord::Migration[4.2]
   def change
     change_column :stacks, :lock_reason, :string, limit: 4096
   end

--- a/db/migrate/20151208214755_reduce_tasks_type_size.shipit_engine.rb
+++ b/db/migrate/20151208214755_reduce_tasks_type_size.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20151112152112)
-class ReduceTasksTypeSize < ActiveRecord::Migration
+class ReduceTasksTypeSize < ActiveRecord::Migration[4.2]
   def change
     change_column :tasks, :type, :string, limit: 10, null: true
   end

--- a/db/migrate/20151208214756_reduce_tasks_stats_size.shipit_engine.rb
+++ b/db/migrate/20151208214756_reduce_tasks_stats_size.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20151112152113)
-class ReduceTasksStatsSize < ActiveRecord::Migration
+class ReduceTasksStatsSize < ActiveRecord::Migration[4.2]
   def change
     change_column :tasks, :status, :string, null: false, default: 'pending', limit: 10
   end

--- a/db/migrate/20151208214757_improve_indexes_on_tasks.shipit_engine.rb
+++ b/db/migrate/20151208214757_improve_indexes_on_tasks.shipit_engine.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit_engine (originally 20151113151323)
-class ImproveIndexesOnTasks < ActiveRecord::Migration
+class ImproveIndexesOnTasks < ActiveRecord::Migration[4.2]
   def change
     add_index :tasks, [:type, :stack_id, :status], name: :index_tasks_by_stack_and_status
     add_index :tasks, [:type, :stack_id, :parent_id], name: :index_tasks_by_stack_and_parent

--- a/db/migrate/20160305140720_increase_tasks_type_size_back.shipit.rb
+++ b/db/migrate/20160305140720_increase_tasks_type_size_back.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160104151742)
-class IncreaseTasksTypeSizeBack < ActiveRecord::Migration
+class IncreaseTasksTypeSizeBack < ActiveRecord::Migration[4.2]
   def change
     change_column :tasks, :type, :string, limit: 20, null: true
   end

--- a/db/migrate/20160305140721_convert_sti_columns.shipit.rb
+++ b/db/migrate/20160305140721_convert_sti_columns.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160104151833)
-class ConvertStiColumns < ActiveRecord::Migration
+class ConvertStiColumns < ActiveRecord::Migration[4.2]
   def up
     Shipit::Task.where(type: 'Task').update_all(type: 'Shipit::Task')
     Shipit::Task.where(type: 'Deploy').update_all(type: 'Shipit::Deploy')

--- a/db/migrate/20160305140722_rename_hooks_url_in_delivery_url.shipit.rb
+++ b/db/migrate/20160305140722_rename_hooks_url_in_delivery_url.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160122165559)
-class RenameHooksUrlInDeliveryUrl < ActiveRecord::Migration
+class RenameHooksUrlInDeliveryUrl < ActiveRecord::Migration[4.2]
   def change
     rename_column :hooks, :url, :delivery_url
   end

--- a/db/migrate/20160305140723_add_allow_concurrency_to_tasks.shipit.rb
+++ b/db/migrate/20160305140723_add_allow_concurrency_to_tasks.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160210183823)
-class AddAllowConcurrencyToTasks < ActiveRecord::Migration
+class AddAllowConcurrencyToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :allow_concurrency, :boolean, null: false, default: false
   end

--- a/db/migrate/20160305140724_create_shipit_commit_deployments.shipit.rb
+++ b/db/migrate/20160305140724_create_shipit_commit_deployments.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160303163611)
-class CreateShipitCommitDeployments < ActiveRecord::Migration
+class CreateShipitCommitDeployments < ActiveRecord::Migration[4.2]
   def change
     create_table :commit_deployments do |t|
       t.references :commit, foreign_key: true

--- a/db/migrate/20160305140725_create_shipit_commit_deployment_statuses.shipit.rb
+++ b/db/migrate/20160305140725_create_shipit_commit_deployment_statuses.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160303170913)
-class CreateShipitCommitDeploymentStatuses < ActiveRecord::Migration
+class CreateShipitCommitDeploymentStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :commit_deployment_statuses do |t|
       t.references :commit_deployment, index: true, foreign_key: true

--- a/db/migrate/20160305140726_add_encrypted_token_to_users.shipit.rb
+++ b/db/migrate/20160305140726_add_encrypted_token_to_users.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160303203940)
-class AddEncryptedTokenToUsers < ActiveRecord::Migration
+class AddEncryptedTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :encrypted_github_access_token, :string
     add_column :users, :encrypted_github_access_token_iv, :string

--- a/db/migrate/20170214043912_add_started_at_and_ended_at_on_tasks.shipit.rb
+++ b/db/migrate/20170214043912_add_started_at_and_ended_at_on_tasks.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160324155046)
-class AddStartedAtAndEndedAtOnTasks < ActiveRecord::Migration
+class AddStartedAtAndEndedAtOnTasks < ActiveRecord::Migration[4.2]
   def up
     add_column :tasks, :started_at, :datetime, null: true
     add_column :tasks, :ended_at, :datetime, null: true

--- a/db/migrate/20170214043913_add_index_for_stack_active_task.shipit.rb
+++ b/db/migrate/20170214043913_add_index_for_stack_active_task.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160426155146)
-class AddIndexForStackActiveTask < ActiveRecord::Migration
+class AddIndexForStackActiveTask < ActiveRecord::Migration[4.2]
   def change
     add_index :tasks, [:status, :stack_id, :allow_concurrency], name: :index_active_tasks
   end

--- a/db/migrate/20170214043914_add_estimated_deploy_duration_to_stacks.shipit.rb
+++ b/db/migrate/20170214043914_add_estimated_deploy_duration_to_stacks.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160502150713)
-class AddEstimatedDeployDurationToStacks < ActiveRecord::Migration
+class AddEstimatedDeployDurationToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :estimated_deploy_duration, :integer, null: false, default: 1
   end

--- a/db/migrate/20170214043915_reorder_active_tasks_index.shipit.rb
+++ b/db/migrate/20170214043915_reorder_active_tasks_index.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160526192650)
-class ReorderActiveTasksIndex < ActiveRecord::Migration
+class ReorderActiveTasksIndex < ActiveRecord::Migration[4.2]
   def change
     remove_index :tasks, name: :index_active_tasks
     add_index :tasks, %i(stack_id allow_concurrency status), name: :index_active_tasks

--- a/db/migrate/20170214043916_add_continuous_delivery_delayed_since_to_stacks.shipit.rb
+++ b/db/migrate/20170214043916_add_continuous_delivery_delayed_since_to_stacks.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160802092812)
-class AddContinuousDeliveryDelayedSinceToStacks < ActiveRecord::Migration
+class AddContinuousDeliveryDelayedSinceToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :continuous_delivery_delayed_since, :datetime, null: true
   end

--- a/db/migrate/20170214043917_add_locked_since_to_stacks.shipit.rb
+++ b/db/migrate/20170214043917_add_locked_since_to_stacks.shipit.rb
@@ -1,5 +1,5 @@
 # This migration comes from shipit (originally 20160822131405)
-class AddLockedSinceToStacks < ActiveRecord::Migration
+class AddLockedSinceToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :locked_since, :datetime, null: true
   end


### PR DESCRIPTION
fixes:
StandardError: An error has occurred, all later migrations canceled.
Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:
  class CreateBaseline < ActiveRecord::Migration[4.2]