### PR TITLE
Add limit to string columns

### DIFF
--- a/db/migrate/20220409130948_add_review_stacks.shipit.rb
+++ b/db/migrate/20220409130948_add_review_stacks.shipit.rb
@@ -1,10 +1,10 @@
-# This migration comes from shipit (originally 20200706145406)
+  # This migration comes from shipit (originally 20200706145406)
 class AddReviewStacks < ActiveRecord::Migration[6.0]
   def change
-    add_column :stacks, :provision_status, :string, null: false, default: :deprovisioned
+    add_column :stacks, :provision_status, :string, limit: 191, null: false, default: :deprovisioned
     add_index :stacks, :provision_status
 
-    add_column :stacks, :type, :string, default: "Shipit::Stack"
+    add_column :stacks, :type, :string, limit: 191, default: "Shipit::Stack"
     add_index :stacks, :type
 
     add_column :stacks, :awaiting_provision, :boolean, null: false, default: false

--- a/db/migrate/20220409130951_recreate_shipit_pull_requests.shipit.rb
+++ b/db/migrate/20220409130951_recreate_shipit_pull_requests.shipit.rb
@@ -5,10 +5,10 @@ class RecreateShipitPullRequests < ActiveRecord::Migration[6.0]
     create_table :pull_requests do |t|
       t.references :stack, null: false
       t.integer :number, null: false
-      t.string :title, limit: 256
+      t.string :title, limit: 191
       t.integer :github_id, limit: 8
-      t.string :api_url, limit: 1024
-      t.string :state
+      t.string :api_url, limit: 191
+      t.string :state, limit: 191
       t.integer :additions, null: false, default: 0
       t.integer :deletions, null: false, default: 0
       t.integer :user_id

--- a/db/migrate/20220409130953_add_provision_pr_stacks_flag_to_repositories.shipit.rb
+++ b/db/migrate/20220409130953_add_provision_pr_stacks_flag_to_repositories.shipit.rb
@@ -2,7 +2,7 @@
 class AddProvisionPrStacksFlagToRepositories < ActiveRecord::Migration[6.0]
   def change
     add_column :repositories, :review_stacks_enabled, :boolean, default: false
-    add_column :repositories, :provisioning_behavior, :string, default: :allow_all
-    add_column :repositories, :provisioning_label_name, :string
+    add_column :repositories, :provisioning_behavior, :string, limit: 191, default: :allow_all
+    add_column :repositories, :provisioning_label_name, :string, limit: 191
   end
 end

--- a/db/migrate/20220409130959_increase_github_team_slug_size.shipit.rb
+++ b/db/migrate/20220409130959_increase_github_team_slug_size.shipit.rb
@@ -1,6 +1,6 @@
 # This migration comes from shipit (originally 20211103154121)
 class IncreaseGithubTeamSlugSize < ActiveRecord::Migration[6.1]
   def change
-    change_column :teams, :slug, :string, limit: 255, null: true
+    change_column :teams, :slug, :string, limit: 191, null: true
   end
 end


### PR DESCRIPTION
Fixes:
ActiveRecord::StatementInvalid: Mysql2::Error: Specified key was too
long; max key length is 767 bytes

https://stackoverflow.com/questions/63158705/rails-migration-mysql2error-specified-key-was-too-long-max-key-length-is-7