### PR TITLE
Migrate from kubernetes-deploy to krane

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk --update add \
   bash \
   && gem install bundler && \
   cd /app ; bundle install --without development test && \
-  gem install kubernetes-deploy --no-document --version=0.30.0
+  gem install krane -f --no-document --version=2.4.6
 
 COPY . /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY . /app
 COPY root/ root/
 RUN chmod -R 700 root/.ssh
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.15.11/bin/linux/amd64/kubectl /usr/bin/kubectl
+ADD https://dl.k8s.io/release/v1.23.5/bin/linux/amd64/kubectl /usr/bin/kubectl
 RUN chmod +x /usr/bin/kubectl
 
 COPY kubeconfig.yml /root/.kube/config

--- a/shipit.yml
+++ b/shipit.yml
@@ -9,6 +9,17 @@ ci:
   require:
     - build
 
-kubernetes:
-  namespace: shipit
-  context: rubygems
+deploy:
+  override:
+    - krane render -f config/deploy/$ENVIRONMENT --bindings=environment=$ENVIRONMENT --current-sha=$REVISION | krane deploy shipit rubygems -f -
+
+rollback:
+  override:
+    - krane render -f config/deploy/$ENVIRONMENT --bindings=environment=$ENVIRONMENT --current-sha=$REVISION | krane deploy shipit rubygems -f -
+
+tasks:
+  restart:
+    action: Restart application
+    description: Trigger the restart of both unicorn and background workers
+    steps:
+      - krane restart shipit rubygems


### PR DESCRIPTION
- krane is new iteration on kubernetes-deploy
- I'll open PRs to migrate this in shipit.yml files (update here they are):
  - https://github.com/rubygems/rubygems.org-db-backups/pull/9
  - https://github.com/rubygems/rubygems.org/pull/3018
  
:information_source: I have ignored https://github.com/rubygems/rubygems-lita since it seems unused. Should we archive that repo and remove it from shipit instance?