### PR TITLE
Enable assume ssl flag to allow alb healthcheck to pass

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,6 +39,10 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  config.assume_ssl = true
+
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug


### PR DESCRIPTION
The ALB target health check is failing, as Rails is responding with an HTTP 301, asking the health check to use HTTP. We need to enable the `assume_ssl` flag to indicate to Rails that we have a load balancer that's terminating TLS.