### PR TITLE
Remove active_record.legacy_connection_handling config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -26,9 +26,6 @@ module Shipit
 
     config.active_job.queue_adapter = :sidekiq
 
-    # Accepting new Rails 7 connection handling
-    config.active_record.legacy_connection_handling = false
-
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading


### PR DESCRIPTION
Rails configuration that has since been removed https://github.com/rubygems/shipit/actions/runs/11360843379/job/31599380728?pr=293