### PR TITLE
update ALB security policy to latest default

### DIFF
--- a/config/deploy/production/ingress.yaml
+++ b/config/deploy/production/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-west-2:048268392960:certificate/4631b699-ff31-461e-84b4-4260cac038d1
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-2021-06
 spec:
   rules:
     - host: shipit.rubygems.org


### PR DESCRIPTION
# What's this about?

Our ALB is old and is currently configured to use out of date versions of TLS, and not allow newer better versions such as 1.3. 

This PR sets the `ssl-policy` for the Shipit load balancer to the latest version [ALB TLS Security Policy](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/describe-ssl-policies.html)