### PR TITLE
add omniauth-github to dependabot ignore list until Shopify fixes it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,5 @@ updates:
     interval: daily
   open-pull-requests-limit: 99
   ignore:
+    # TODO: Remove me when https://github.com/Shopify/shipit-engine/pull/1314 is resolved
     - dependency-name: "omniauth-github"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 99
+  ignore:
+    - dependency-name: "omniauth-github"


### PR DESCRIPTION
We're blocked until Shopify releases a fix, whenever that will happen.