### PR TITLE
Migrate github_id in commit_deployments table to bigint

### DIFF
--- a/db/migrate/20250826025030_change_github_id_to_bigint_in_commit_deployments.rb
+++ b/db/migrate/20250826025030_change_github_id_to_bigint_in_commit_deployments.rb
@@ -1,0 +1,9 @@
+class ChangeGithubIdToBigintInCommitDeployments < ActiveRecord::Migration[7.1]
+  def up
+    change_column :commit_deployments, :github_id, :bigint
+  end
+
+  def down
+    change_column :commit_deployments, :github_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_14_190527) do
+ActiveRecord::Schema[7.1].define(version: 2025_08_26_025030) do
   create_table "api_clients", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.text "permissions"
     t.integer "creator_id"
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_14_190527) do
   create_table "commit_deployments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_bin", force: :cascade do |t|
     t.integer "commit_id"
     t.integer "task_id"
-    t.integer "github_id"
+    t.bigint "github_id"
     t.string "api_url"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false


### PR DESCRIPTION
We're currently getting the following error in Shipit:

```
2025-08-26 02:49:08.406Z 2025-08-26T02:49:08.406Z pid=1 tid=v1l WARN: {"context":"Job raised exception","job":{"retry":true,"queue":"default","wrapped":"Shipit::CreateOnGithubJob","args":[{"job_class":"Shipit::CreateOnGithubJob","job_id":"7271a883-0862-4604-93e3-85e4a5935434","provider_job_id":null,"queue_name":"default","priority":null,"arguments":[{"_aj_globalid":"gid://shipit/Shipit::CommitDeployment/8153"}],"executions":0,"exception_executions":{},"locale":"en","timezone":"UTC","enqueued_at":"2025-08-26T02:05:53.929210636Z","scheduled_at":null}],"class":"ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper","jid":"e46e73cbe0f7fb52bcc51ebf","created_at":1756173953.9292488,"enqueued_at":1756176548.111411,"error_message":"2917557735 is out of range for ActiveModel::Type::Integer with limit 4 bytes","error_class":"ActiveModel::RangeError","failed_at":1756173954.552252,"retry_count":6,"retried_at":1756175205.9996383}}
2025-08-26 02:49:08.406Z 2025-08-26T02:49:08.406Z pid=1 tid=v1l WARN: ActiveModel::RangeError: 2917614374 is out of range for ActiveModel::Type::Integer with limit 4 bytes
```

I believe the attribute in question is the `github_id`, which this Pull Request is migrating to a big int.