### PR TITLE
Ensure required ENV variables are present

### DIFF
--- a/config/deploy/production/schedule.yaml.erb
+++ b/config/deploy/production/schedule.yaml.erb
@@ -101,6 +101,21 @@ spec:
                   secretKeyRef:
                     name: production
                     key: github_private_key
+              - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: production
+                    key: active_record_encryption_primary_key
+              - name: ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: production
+                    key: active_record_encryption_deterministic_key
+              - name: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+                valueFrom:
+                  secretKeyRef:
+                    name: production
+                    key: active_record_encryption_key_derivation_salt
             securityContext:
               privileged: false
             volumeMounts:
@@ -216,6 +231,21 @@ spec:
                   secretKeyRef:
                     name: production
                     key: github_private_key
+              - name: ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: production
+                    key: active_record_encryption_primary_key
+              - name: ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: production
+                    key: active_record_encryption_deterministic_key
+              - name: ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT
+                valueFrom:
+                  secretKeyRef:
+                    name: production
+                    key: active_record_encryption_key_derivation_salt
             securityContext:
               privileged: false
             volumeMounts:


### PR DESCRIPTION
Our scheduled shipit pods fail consistently when in the pending state because they're missing the required ENV variables to run their cron-based jobs. Adding the variables to the corresponding deploys to prevent the failures and allow the pods to spin up.

<img width="927" height="662" alt="image" src="https://github.com/user-attachments/assets/c38926a8-0cd7-4e45-8add-1a306c5bb539" />

These are surfacing via 👇 

```
ActiveRecord::Encryption::Errors::Configuration: Missing Active Record encryption credential: active_record_encryption.primary_key (ActiveRecord::Encryption::Errors::Configuration)
rake aborted!
(See full trace by running task with --trace)
Tasks: TOP => cron:hourly => cron:refresh_users
```