### PR TITLE
Remove `github_api_token` secret

### DIFF
--- a/config/deploy/production/db-migrate.yaml.erb
+++ b/config/deploy/production/db-migrate.yaml.erb
@@ -55,11 +55,6 @@ spec:
           secretKeyRef:
             name: production
             key: github_oauth_secret
-      - name: GITHUB_API_TOKEN
-        valueFrom:
-          secretKeyRef:
-            name: production
-            key: github_api_token
       - name: GITHUB_APP_ID
         valueFrom:
           secretKeyRef:

--- a/config/deploy/production/puma.yaml.erb
+++ b/config/deploy/production/puma.yaml.erb
@@ -99,11 +99,6 @@ spec:
               secretKeyRef:
                 name: production
                 key: github_oauth_secret
-          - name: GITHUB_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: production
-                key: github_api_token
           - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:

--- a/config/deploy/production/schedule.yaml.erb
+++ b/config/deploy/production/schedule.yaml.erb
@@ -76,11 +76,6 @@ spec:
                   secretKeyRef:
                     name: production
                     key: github_oauth_secret
-              - name: GITHUB_API_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: production
-                    key: github_api_token
               - name: GITHUB_APP_ID
                 valueFrom:
                   secretKeyRef:
@@ -196,11 +191,6 @@ spec:
                   secretKeyRef:
                     name: production
                     key: github_oauth_secret
-              - name: GITHUB_API_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: production
-                    key: github_api_token
               - name: GITHUB_APP_ID
                 valueFrom:
                   secretKeyRef:

--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -10,7 +10,6 @@
         "shipit_home_dir": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:ch4Gvck4X8Xxds3VGioIwUgIVff7KWpY:xjszQF5XS/91OAzd59xx69AyR1Y=]",
         "github_oauth_id": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:Odgi1PKqd4IzJ0bMw+1nvLjvErBp5o6x:IMgoLgCOsUJGzJ1i5t3KsjmPoqWd1fqJpLTh+H+ehyLtC08C]",
         "github_oauth_secret": "EJ[1:+wh4vor/bo1lnAODniywg46bsDeIgMr14/yJrpdPQz8=:+Nyk9I27fWfEvpV3ZkBR8wmFQsUBRFzr:tUQGvV5doy/SFngJxmfBZt8bXJjEH/8LkSSQ0U9eznQcwS14xa1YIp456h4CR7rQN74vKPeenyU=]",
-        "github_api_token": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:1YpGr6gOi8pDswz0SBVt7BG6ey4WMTVf:y8mPc+vYmng8lAuKSU1QIYAUQAC2V1L7g2eI3tlFQxA9h+ixYwuxsyU+IRTqQqP2qjvtkl9MC0I=]",
         "redis_url": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:jJV24p7UbF3zfq9ttW4m6+WQTRtpvRKA:PDxgp5RuBiPArXIIrPOyI30XFB+PPx/wHxg+8a7ndepTlh48aCpwc6cYDpOZd4bNXxMO7AC7ULVEsuJ5qdfYZvvZz3Ivmss45g==]",
         "github_app_id": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:vzykCK7zK9MgCJz6RVLBFyJJIS0B8EAN:Zy92NzFhzUEJFY1KQoopx3E0KwNc]",
         "github_installation_id": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:utFP/mTowcIdVNwKIVL/yS/S/vG3OuW7:dd5XY+fC7lQcEaOVHyBPXc0KKtU/8vI=]",

--- a/config/deploy/production/sidekiq.yaml.erb
+++ b/config/deploy/production/sidekiq.yaml.erb
@@ -78,11 +78,6 @@ spec:
               secretKeyRef:
                 name: production
                 key: github_oauth_secret
-          - name: GITHUB_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: production
-                key: github_api_token
           - name: GITHUB_APP_ID
             valueFrom:
               secretKeyRef:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,8 +15,6 @@ production:
     key_derivation_salt: <%= ENV['ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT'] %>
   secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
   host: <%= ENV['SHIPIT_HOST'] %>
-  github_api:
-    access_token: <%= ENV['GITHUB_API_TOKEN'] %>
   github:
     app_id: <%= ENV['GITHUB_APP_ID'] %>
     installation_id: <%= ENV['GITHUB_INSTALLATION_ID'] %>


### PR DESCRIPTION
Like https://github.com/rubygems/shipit/pull/382, this is also seems to be unused since the change to use Github apps in `shipit-engine` 

https://github.com/Shopify/shipit-engine/commit/9ed9adca80a2fcaef43a18ee3e58fd1401a656ff#diff-4ca53116333428d7d34e6d2a9a64069655c8c37d5d36b856320ac1a0c4cb9b23