### PR TITLE
Remove openssh-client from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN apk --update add \
   libc-dev \
   linux-headers \
   git \
-  openssh-client \
   bash \
   && gem install bundler && \
   cd /app ; bundle install --without development test && \


### PR DESCRIPTION
Follow up for https://github.com/rubygems/shipit/pull/382

`ssh-key` secret was removed so we don't need `openssh-client` anymore.