### PR TITLE
Rotate `secret_key_base`

### DIFF
--- a/config/deploy/production/secrets.ejson
+++ b/config/deploy/production/secrets.ejson
@@ -4,7 +4,7 @@
     "production": {
       "_type": "Opaque",
       "data": {
-        "secret_key_base": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:bTdEApYPX+cFOeF5ygma/mS1F1PW3q3R:r1J8uD1IgIvUAc07wOncfwzdj5XkmNK5NsweXMLHacpJw4wU54YBzrUZBHtVF6BF8v7f4KYDwiWG0931aO+QMx35aqFNd4a0rSbuL3hev1zmWVt3VoE+yqahBAZSgF8SrBivVzC0BMbNiUIggxHEanSz9+h0l1bWXR7yzkCr2RDwDg+JSF35xTCIL72HKSch]",
+        "secret_key_base": "EJ[1:AiiE7E7a6SSU/F46Mkk6+FYkco4pRKsc29Lw6igR5x8=:tbmvq7ajyBMHdQ9JKvoxiufUKTcsGS+L:+/d4rVhl66El3S5SLRHAukZc6y02Rjl80oFVHD2TLQekQnnd1nhc6S38Zd1mtISnxC0ngAbJh1pPE0FOpXJPRfzK5U4LhY+6GG/oxUNel6oZTWcV6xPNqHWus54TkuuZL43lDREA8A8a4scvQ8Qssq3KuwdfyBllQsxPsvPADzwW0KDGbJqzkTthjmo/zWwI]",
         "shipit_host": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:4QeqNu2+K+pOHhhyfxq+DOoGETmd1i3Z:Ks424ro9d0e2aMl2jOD8NbvZ/8tpTKvILsh3QGXjQaJSLrok4Q7VW8d8tQ==]",
         "database_url": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:PB5Rw2CP1zbtPVcPISwbjVgShEEFWcfM:yKuXBZ38WITYBzsMT2sElRng1BFuRtQdsCWOh4I8omy3k/Iz5+oh8S2+ybedXzZ1022Q+lVlZMLr/1yZX3uDN2x+lTXFLWm/JaYH53ZDP4ZLFd+Hg5V/ouZFEHNK1ZW71YBw6lMXBLHJaBHXqOA1nK28+cEbOZ6aLxcSieK+LsQEleUu]",
         "shipit_home_dir": "EJ[1:ZTIwYgS/oHltY/yux+wGJDii5t+T7Z+DxY+evoYSWHc=:ch4Gvck4X8Xxds3VGioIwUgIVff7KWpY:xjszQF5XS/91OAzd59xx69AyR1Y=]",


### PR DESCRIPTION
With the amount of users on shipit, we're going to take the inconvenience of getting folks to reauthenticate rather than implementing a cookie rotator.

Another use of the `secret_key_base` is a fallback for Active Record encryption but it won't be hit since we have it configured with another value. https://github.com/Shopify/shipit-engine/blob/main/lib/shipit/engine.rb#L14